### PR TITLE
Setup Semgrep on repository

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: Semgrep
+
+on:
+  pull_request: {}
+
+  push:
+    branches:
+      - master
+      - main
+
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
+    if: (github.repository_owner == 'auth0-samples')
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - if: (github.actor != 'dependabot[bot]')
+        run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
This PR adds a Semgrep GitHub workflow to the repository, like the other sample repos. The token has already been configured on the repo.