### PR TITLE
Updated pubspec.yaml to include file: ^6.1.4 ref

### DIFF
--- a/sample/pubspec.yaml
+++ b/sample/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
     sdk: flutter
   flutter_dotenv: ^5.0.2
   google_fonts: ^3.0.1
+  file: ^6.1.4
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Explicitly setting the file version used as this was causing issues if default build was using a version such as 6.1.2..

- [x] All new/changed/fixed functionality is covered by tests (or N/A)

NA

### 📋 Changes

Explicitly setting the file version used as this was causing issues if default build was using a version such as 6.1.2 would cause it not to compile as references by the project or by flutter_dotenv was using methods that do not exist in 6.1.2.

### 📎 References

../../../../AppData/Local/Pub/Cache/hosted/pub.dev/file-6.1.2/lib/src/interface/file.dart:15:16: Error: The method 'File.create' has fewer named arguments than those of overridden method 'File.create'.
  Future<File> create({bool recursive = false});
               ^
org-dartlang-sdk:///third_party/dart/sdk/lib/io/file.dart:232:16: Context: This is the overridden method ('create').
  Future<File> create({bool recursive = false, bool exclusive = false});
               ^
../../../../AppData/Local/Pub/Cache/hosted/pub.dev/file-6.1.2/lib/src/interface/file.dart:15:16: Error: The method 'File.create' doesn't have the named parameter 'exclusive' of overridden method 'File.create'.
  Future<File> create({bool recursive = false});
               ^
org-dartlang-sdk:///third_party/dart/sdk/lib/io/file.dart:232:16: Context: This is the overridden method ('create').
  Future<File> create({bool recursive = false, bool exclusive = false});
               ^
../../../../AppData/Local/Pub/Cache/hosted/pub.dev/file-6.1.2/lib/src/forwarding/forwarding_file.dart:22:8: Error: The method 'ForwardingFile.createSync' has fewer named arguments than those of overridden method 'File.createSync'.
  void createSync({bool recursive = false}) =>
       ^
org-dartlang-sdk:///third_party/dart/sdk/lib/io/file.dart:248:8: Context: This is the overridden method ('createSync').
  void createSync({bool recursive = false, bool exclusive = false});
       ^
../../../../AppData/Local/Pub/Cache/hosted/pub.dev/file-6.1.2/lib/src/forwarding/forwarding_file.dart:22:8: Error: The method 'ForwardingFile.createSync' doesn't have the named parameter 'exclusive' of overridden method 'File.createSync'.
  void createSync({bool recursive = false}) =>
       ^
org-dartlang-sdk:///third_party/dart/sdk/lib/io/file.dart:248:8: Context: This is the overridden method ('createSync').
  void createSync({bool recursive = false, bool exclusive = false});

### 🎯 Testing

Pull existing main branch, load code, compile - fails
Add reference for file: 6.1.4^ - success
