### PR TITLE
Add CI job for running macOS smoke tests [SDK-4711] 5/5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,3 +106,38 @@ jobs:
               with:
                 platform: ${{ env.platform }}
                 destination: 'platform=iOS Simulator,name=iPhone 15'
+
+    test-macos-smoke:
+        name: Run native macOS smoke tests using Xcode ${{ matrix.xcode }}
+        needs: authorize
+        runs-on: macos-13
+        environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
+
+        env:
+            platform: macOS
+            USER_EMAIL: ${{ secrets.USER_EMAIL }}
+            USER_PASSWORD: ${{ secrets.USER_PASSWORD }}
+
+        strategy:
+          matrix:
+            xcode:
+              - '15.0.1'
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+            - name: Set up environment
+              uses: ./.github/actions/setup-darwin
+              with:
+                platform: ${{ env.platform }}
+                flutter: ${{ env.flutter }}
+                xcode: ${{ matrix.xcode }}
+                auth0-domain: ${{ vars.AUTH0_DOMAIN }}
+                auth0-client-id: ${{ vars.AUTH0_CLIENT_ID }}
+
+            - name: Run macOS smoke tests
+              uses: ./.github/actions/smoke-tests-darwin
+              with:
+                platform: ${{ env.platform }}
+                destination: platform=macOS,arch=x86_64


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)

<!--
❗ The above item is required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds a CI job for running the macOS smoke tests.
